### PR TITLE
feat(auth): Google login via NextAuth v5 (App Router)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Analytics
-NEXT_PUBLIC_GA_ID=
+NEXT_PUBLIC_GA_ID=G-029W6XTT9V
 
 # Stripe (postavi u Vercel env, ne u repo)
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
+# Auth (NextAuth v5)
+AUTH_SECRET=qetuop]sfhk;\zcbm.wryip]sfhk;\`z
+AUTH_GOOGLE_ID=767576700122-1uiqma4b37uiopb3pd581hmhqfckeo67.apps.googleusercontent.com
+AUTH_GOOGLE_SECRET=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

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from "@/auth";
+export const { GET, POST } = handlers;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,14 @@
+export default function LoginPage() {
+return (
+<div className="mx-auto max-w-xl px-6 py-16">
+<h1 className="text-3xl font-bold">Sign in</h1>
+<p className="mt-2 text-slate-600">Use your Google account to continue.</
+p>
+<div className="mt-6">
+<a className="inline-flex rounded-2xl border bg-brand px-4 py-2 textwhite" href="/api/auth/signin/google">
+Continue with Google
+</a>
+</div>
+</div>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -1,18 +1,19 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+
 export const {
-handlers,
-auth,
-signIn,
-signOut,
+  handlers,
+  auth,
+  signIn,
+  signOut,
 } = NextAuth({
-trustHost: true,
-session: { strategy: "jwt" },
-secret: process.env.AUTH_SECRET,
-providers: [
-Google({
-clientId: process.env.AUTH_GOOGLE_ID ?? "",
-clientSecret: process.env.AUTH_GOOGLE_SECRET ?? "",
-}),
-],
+  trustHost: true,
+  session: { strategy: "jwt" },
+  secret: process.env.AUTH_SECRET,
+  providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID ?? "",
+      clientSecret: process.env.AUTH_GOOGLE_SECRET ?? "",
+    }),
+  ],
 });

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,18 @@
+import NextAuth from "next-auth";
+import Google from "next-auth/providers/google";
+export const {
+handlers,
+auth,
+signIn,
+signOut,
+} = NextAuth({
+trustHost: true,
+session: { strategy: "jwt" },
+secret: process.env.AUTH_SECRET,
+providers: [
+Google({
+clientId: process.env.AUTH_GOOGLE_ID ?? "",
+clientSecret: process.env.AUTH_GOOGLE_SECRET ?? "",
+}),
+],
+});

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,21 +1,33 @@
 import Link from "next/link";
 import Image from "next/image";
-
-export function Header() {
-  return (
-    <header className="sticky top-0 z-40 border-b bg-white/70 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
-        <Link href="/" className="flex items-center gap-2">
-          <Image src="/images/logo-placeholder.svg" width={28} height={28} alt="Logo" />
-          <span className="text-lg font-semibold">SellerRescueHub</span>
-        </Link>
-        <nav className="flex items-center gap-6 text-sm">
-          <Link href="/pricing">Pricing</Link>
-          <Link href="/privacy">Privacy</Link>
-          <Link href="/terms">Terms</Link>
-          <Link href="/login" className="font-medium">Login</Link>
-        </nav>
-      </div>
-    </header>
-  );
+import { auth } from "@/auth";
+export async function Header() {
+const session = await auth();
+return (
+2
+<header className="sticky top-0 z-40 border-b bg-white/70 backdrop-blur">
+<div className="mx-auto flex max-w-6xl items-center justify-between px-6
+py-3">
+<Link href="/" className="flex items-center gap-2">
+<Image src="/images/logo-placeholder.svg" width={28} height={28}
+alt="Logo" />
+<span className="text-lg font-semibold">SellerRescueHub</span>
+</Link>
+<nav className="flex items-center gap-6 text-sm">
+<Link href="/pricing">Pricing</Link>
+<Link href="/privacy">Privacy</Link>
+<Link href="/terms">Terms</Link>
+{session ? (
+<div className="flex items-center gap-3">
+<span className="text-slate-600 hidden sm:inline">Hi,
+{session.user?.name ?? "user"}</span>
+<a href="/api/auth/signout" className="font-medium">Logout</a>
+</div>
+) : (
+<a href="/api/auth/signin" className="font-medium">Login</a>
+)}
+</nav>
+</div>
+</header>
+);
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,8 +4,7 @@ import { auth } from "@/auth";
 export async function Header() {
 const session = await auth();
 return (
-2
-<header className="sticky top-0 z-40 border-b bg-white/70 backdrop-blur">
+  <header className="sticky top-0 z-40 border-b bg-white/70 backdrop-blur">
 <div className="mx-auto flex max-w-6xl items-center justify-between px-6
 py-3">
 <Link href="/" className="flex items-center gap-2">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sellerrescuehub",
-  "private": true,
   "version": "0.1.0",
+  "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -14,8 +14,8 @@
     "react-dom": "18.3.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.441.0",
-    "stripe": "^14.0.0"
     "next-auth": "^5.0.0",
+    "stripe": "^14.0.0"
   },
   "devDependencies": {
     "typescript": "^5.5.4",
@@ -27,5 +27,8 @@
     "autoprefixer": "^10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.7"
+  },
+  "engines": {
+    "node": ">=18.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.441.0",
     "stripe": "^14.0.0"
+    "next-auth": "^5.0.0",
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react-dom": "18.3.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.441.0",
-    "next-auth": "^5.0.0",
+    "next-auth": "5.0.0-beta.29",
     "stripe": "^14.0.0"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "baseUrl": ".",
     "paths": {
       "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"]
+      "@/lib/*": ["lib/*"],
       "@/auth": ["auth"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "paths": {
       "@/components/*": ["components/*"],
       "@/lib/*": ["lib/*"]
-      "@/auth": ["auth"],
+      "@/auth": ["auth"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "paths": {
       "@/components/*": ["components/*"],
       "@/lib/*": ["lib/*"]
+      "@/auth": ["auth"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
This PR adds Google OAuth login with NextAuth v5, integrates session awareness into the Header, and
provides a minimal Login page. It uses JWT sessions (no DB yet). This is the quickest secure path to ship
auth; Apple + magic-link (Resend) and DB persistence will follow in Day 3.

**Why this change**
We want users to sign in now (Google first).
Server Components-friendly setup with NextAuth v5.
No client state needed — we read the session via server-side auth() in Header.

**Summary of changes**
Add next-auth dependency.
Create shared NextAuth config in auth.ts (root), export auth and handlers .
Add API route app/api/auth/[...nextauth]/route.ts wiring GET / POST from auth.ts .
Update components/layout/Header.tsx to show Login/Logout depending on session state.
Add a minimal app/login/page.tsx with a sign-in CTA.
Extend .env.example with AUTH_SECRET , AUTH_GOOGLE_ID , AUTH_GOOGLE_SECRET .

PR Checklist
[ ] next-auth@^5 installed
[ ] auth.ts added and exports { handlers, auth }
[ ] app/api/auth/[...nextauth]/route.ts re-exports { GET, POST }
[ ] Header shows Login/Logout based on session
[ ] /login page exists and links to /api/auth/signin/google
[ ] .env.example updated











